### PR TITLE
Improve workflow of releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,137 @@
+name: Build image on Release
+
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+    inputs:
+      label:
+        description: 'Image tag (e.g. v1.2.3 or 1.2.3)'
+        required: true
+        type: string
+      latest:
+        description: 'Also tag as :latest?'
+        type: boolean
+        default: true
+        required: false
+      push_ghcr:
+        description: 'Push to GHCR?'
+        type: boolean
+        default: true
+        required: false
+      push_dockerhub:
+        description: 'Push to Docker Hub?'
+        type: boolean
+        default: true
+        required: false
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: ${{ github.event_name == 'release' || fromJSON(inputs.push_dockerhub || 'false') }}
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set image and tag
+        id: vars
+        shell: bash
+        run: |
+          GHCR_IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}"
+
+          REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          DOCKERHUB_IMAGE="docker.io/${{ secrets.DOCKERHUB_USERNAME }}/${REPO_NAME,,}"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            TAG="${{ inputs.label }}"
+            LATEST="${{ inputs.latest }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+            LATEST=true
+          fi
+
+          VERSION="${TAG#v}"
+
+          {
+            echo "GHCR_IMAGE=${GHCR_IMAGE}"
+            echo "DOCKERHUB_IMAGE=${DOCKERHUB_IMAGE}"
+            echo "VERSION=${VERSION}"
+            echo "LATEST=${LATEST}"
+
+            echo "TAGS_GHCR<<EOF"
+            echo "${GHCR_IMAGE}:${VERSION}"
+            [[ "${LATEST}" == "true" ]] && echo "${GHCR_IMAGE}:latest"
+            echo "EOF"
+
+            echo "TAGS_DH<<EOF"
+            echo "${DOCKERHUB_IMAGE}:${VERSION}"
+            [[ "${LATEST}" == "true" ]] && echo "${DOCKERHUB_IMAGE}:latest"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Docker labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.vars.outputs.GHCR_IMAGE }}
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.version=${{ steps.vars.outputs.VERSION }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Build & push to GHCR (amd64)
+        if: ${{ github.event_name == 'release' || fromJSON(inputs.push_ghcr || 'false') }}
+        id: docker_build_ghcr
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          pull: true
+          push: true
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+          cache-from: type=registry,ref=${{ steps.vars.outputs.GHCR_IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ steps.vars.outputs.GHCR_IMAGE }}:buildcache,mode=max
+          tags: ${{ steps.vars.outputs.TAGS_GHCR }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build & push to Docker Hub (amd64)
+        if: ${{ github.event_name == 'release' || fromJSON(inputs.push_dockerhub || 'false') }}
+        id: docker_build_dh
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          pull: true
+          push: true
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+          cache-from: type=registry,ref=${{ steps.vars.outputs.GHCR_IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ steps.vars.outputs.GHCR_IMAGE }}:buildcache,mode=max
+          tags: ${{ steps.vars.outputs.TAGS_DH }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       label:
-        description: 'Image tag (e.g. v1.2.3 or 1.2.3)'
+        description: 'Image tag (e.g. 1.2.3)'
         required: true
         type: string
       latest:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
             LATEST=true
           fi
 
-          VERSION="${TAG#v}"
+          VERSION="$TAG"
 
           {
             echo "GHCR_IMAGE=${GHCR_IMAGE}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       label:
-        description: 'Image tag (e.g. 1.2.3)'
+        description: 'Image tag (e.g. v1.2.3)'
         required: true
         type: string
       latest:
@@ -26,7 +26,7 @@ on:
         required: false
 
 permissions:
-  contents: write
+  contents: read
   packages: write
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
             LATEST=true
           fi
 
-          VERSION="$TAG"
+          VERSION="${TAG#v}"
 
           {
             echo "GHCR_IMAGE=${GHCR_IMAGE}"


### PR DESCRIPTION
Hi Philip! Hope you are doing well.

I wanted to make a github workflow to better help you with releases.
I have found dockerhub to sometimes be slow (download speed wise) and get rate limited, so thought why not help out both you and me.
This workflow would push the image to both registries on release, saving you from having to do things from a terminal or docker desktop manually. So, problem solved! (hopefully haha)

I want to go over the features of the workflow and also demonstrate what it can do.
You can find my repo's packages [here](https://github.com/HyperNylium/mkv-auto/pkgs/container/mkv-auto) and the dockerhub images [here](https://hub.docker.com/r/hypernylium/mkv-auto/tags)

Firstly, the automation part of things. Every time you make a release, it will get the tag for said release and make that the docker image tag. It will build the image like any other, and push that to both dockerhub and ghcr.io.

If you have any problems with the release or something and decide you need to push again but dont want to make another release (or something else happens), i have also included a manual run option where you can manually input the image tag version, if the image should also be tagged with `:latest`, and if it should upload to dockerhub and ghcr.io.
By default with the release creation (not a manual run), it will push both the version tag and `:latest` tag to dockerhub and ghcr.io.

<img width="402" height="338" alt="image" src="https://github.com/user-attachments/assets/db5181e5-1ea6-4099-b3d3-9de826a0960c" />

Now lets talk speed. Since the image takes ~20 minutes to build on github's runners, i made it so it caches to a `:buildcache` tag in ghcr.io. I did this because github's own cache expires after 7 days of no use. So next time you did a release say, a month from now, that cache would have expired and would have taken ~20 minutes to build again.
With this method, it will put all cache that it would have put into github's 7 day system into the container registry itself.
It will keep this tag only on ghcr.io and will not push the cache to dockerhub.

On the topic about speed, let me give you some more details about that.
On the first run, it will take ~20 minutes to build. It will create the image itself and the cache (btw, the cache is like ~1.6-1.8GB haha)
On later runs, depending on code changes, it will take anywhere from 40 seconds to 5 minutes to finish. This includes the image build and upload process to both registries.

Now lets talk money. Since your repo is public and the image will also be public, github will not charge for image storage, cache, or github action run minutes.
However, there is a catch. When you first run this and push the image to ghcr.io, there is a chance the image will upload as a private image, which does get charged for storage.
Once the action completes, you just need to go into the package settings and make sure the settings look like this:

<img width="1468" height="710" alt="image" src="https://github.com/user-attachments/assets/aab4852c-592d-4906-a41a-e06a4617e776" />

<img width="1190" height="1087" alt="image" src="https://github.com/user-attachments/assets/959bc02d-38e7-4bf2-9ede-64204e5b6023" />

The option to upload to ghcr.io will work out of the box. You can even make another repo and copy-paste this workflow in there to test things out yourself. There aren't any hard-coded things that would hinder its portability from repo to repo.

The one thing that will not work out of the box is uploading to dockerhub. However, it is super easy to setup!
You just need to create a "Personal Access Token" from "[profile icon] > Account settings > Settings (dropdown) > Personal Access Token". Then click on "Generate new token". Give whatever name you want and copy the part that looks like a token (should have a whole bunch of underscores and may start with `dckr_pat_...`).
Make sure the token's permissions look like this:

<img width="920" height="580" alt="image" src="https://github.com/user-attachments/assets/77fcecca-e87d-49f8-a1a6-526f79c90ebd" />

Then you go to settings in the repo, "Secrets and variables > Actions" and make sure you have things setup like this where `DOCKERHUB_USERNAME` value would be "philiptn" (without quotes) and `DOCKERHUB_TOKEN` would have your Personal Access Token copied from dockerhub. Make sure they are repository secrets.

<img width="1026" height="262" alt="image" src="https://github.com/user-attachments/assets/301ab9c1-d241-4efa-a32c-63d0a4b2251f" />

And thats it! That is all the config you need to do. Just check permissions for the ghcr.io package and make repo secrets to push to dockerhub.

If you would rather push to dockerhub yourself for releases, i can remove the dockerhub parts and only include the ghcr.io parts, which will work out of the box and doesn't need any config.
I would love if mkv-auto was available on ghcr too :)

I opened the PR to the main branch since this is a workflow, which is a little tricky to test when the main/master branch doesn't have the workflow at all.
If you would like to test it yourself without merging, please feel free to copy-paste the .yml file to your repo of choosing ;)

And of course, if you have any questions/need help setting things up, please feel free to ask away!